### PR TITLE
Django 4.0+ compatibility

### DIFF
--- a/smartfields/urls.py
+++ b/smartfields/urls.py
@@ -1,4 +1,9 @@
-from django.conf.urls import url
+try:
+    # for django >=4.0
+    from django.urls import re_path as url
+except:
+    # for django <4.0
+    from django.conf.urls import url
 
 from smartfields.views import FileUploadView
 

--- a/smartfields/utils.py
+++ b/smartfields/utils.py
@@ -3,7 +3,15 @@ import os, errno, uuid, threading
 from django.conf import settings
 from django.core import validators
 from django.core.files import base, temp
-from django.utils.encoding import force_text
+try:
+    # for django >=4.0
+    import django
+    from django.utils.encoding import force_str
+    django.utils.encoding.force_text = force_str
+except:
+    raise
+    # for django <4.0
+    from django.utils.encoding import force_text
 from six.moves import queue as six_queue
 try:
     from django.utils.deconstruct import deconstructible


### PR DESCRIPTION
This PR should add compatibility for django 4+, after which force_text() was deprecated in favor of force_str(), and url() was deprecated.  The re_path() function is a drop-in replacement for url().

There is not currently any test coverage, so I'd appreciate it if anyone has older versions of django they can test with.  I'm currently doing my own testing with a recently updated application.